### PR TITLE
Fix protocol to fetch the web font and jQuery

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,8 +9,8 @@
 	<link rel="shortcut icon" type="image/png" href="favicon.png"/>
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<!--<script src="js/less.js"></script>-->
-	<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
+	<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/examples.html
+++ b/examples.html
@@ -9,8 +9,8 @@
 	<link rel="shortcut icon" type="image/png" href="favicon.png"/>
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<!--<script src="js/less.js"></script>-->
-	<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
+	<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/getting-started.html
+++ b/getting-started.html
@@ -9,8 +9,8 @@
 	<link rel="shortcut icon" type="image/png" href="favicon.png"/>
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<!--<script src="js/less.js"></script>-->
-	<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
+	<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 	<link rel="shortcut icon" type="image/png" href="favicon.png"/>
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<!--<script src="js/less.js"></script>-->
-	<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
+	<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/reference.html
+++ b/reference.html
@@ -9,8 +9,8 @@
 	<link rel="shortcut icon" type="image/png" href="favicon.png"/>
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<!--<script src="js/less.js"></script>-->
-	<script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
+	<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700|Source+Code+Pro:300' rel='stylesheet' type='text/css'>
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
Hey, just noticed your page can’t load web fonts and jQuery in some browsers (i.e. Chrome) due to the mixed protocols used. GitHub Pages uses HTTPS while you were requesting the web font and the JS library via HTTP.

**Before:**
![before](https://cloud.githubusercontent.com/assets/11782/22686462/861b0528-ed24-11e6-94e8-dbdd5bb17a5e.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/11782/22686465/89a9ade8-ed24-11e6-9c6f-09c9b08039c3.png)